### PR TITLE
Quick fixes for Liquid Tests errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,58 +2,46 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
-## [1.5.0]
+## [1.6.0]
 
-### Added
+- Implement Quick Fixes
+  - Remove row when the value provided by the API is "nothing" (row doesn't exists)
+  - Replace the expected value with the one got from the API response.
+
+## [1.5.0]
 
 - Dynamically compare the Error's list from the the last test run with the content of the file. When the file is updated to solve the issue, the error should be gone from the interface (but it is still stored)
 
 ## [1.4.3]
 
-### Updated
-
 - Update dependencies. Sf-toolkit to v1.5.2
 
 ## [1.4.2]
 
-### Updated
-
 - Update dependencies. Sf-toolkit to v1.5.1
 
 ## [1.4.1]
-
-## Added
 
 - Update sf-toolkit to v1.4.1
 - Output channel: extra logging when test run fails. Close/Prevent HTML panel
 
 ## [1.4.0]
 
-### Added
-
 - HTML render of templates inside Visual Studio Code while running a Liquid Test
 
 ## [1.2.0]
-
-### Updated
 
 - Schema for Liquid Tests updated
 
 ## [1.1.1]
 
-### Updated
-
-- Wrong link in README
+- Updated: Wrong link in README
 
 ## [1.1.0]
-
-### Added
 
 - Show only the statusBar icon when there is a YAML file opened in the activeTab
 
 ## [1.0.0]
-
-### Added
 
 - SF-Toolkit added as a dependency.
 - Run your Liquid Tests from the Extension.
@@ -61,20 +49,14 @@ All notable changes to the "silverfin-development-toolkit" extension will be doc
 
 ## [0.0.3]
 
-### Updated
-
 - Replaced path for the JSON Schema (from a local file to an external file). This change will make the schema read-only for users.
 
 ## [0.0.2]
 
-### Updated
-
-- Local paths for schemas and snippets (`src` directory was omitted when publishing).
+- Updated local paths for schemas and snippets (`src` directory was omitted when publishing).
 
 ## [0.0.1]
 
-### Added
-
-- JSON Schema for liquid test written in YAML.
-- YAML Code snippet of a sample test.
-- Red Hat's YAML extension dependency.
+- Added JSON Schema for liquid test written in YAML.
+- Added YAML Code snippet of a sample test.
+- Added Red Hat's YAML extension dependency.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "redhat.vscode-yaml"
   ],
   "dependencies": {
-    "sf_toolkit": "github:silverfin/sf-toolkit"
+    "sf_toolkit": "github:silverfin/sf-toolkit",
+    "yaml": "^2.2.1"
   },
   "contributes": {
     "languages": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import FirmIdCommand from "./lib/firmIdCommand";
+import { LiquidTestFixer } from "./lib/quickFixes";
 import StatusBarItem from "./lib/statusBarItem";
 import * as types from "./lib/types";
 import * as utils from "./lib/utils";
@@ -39,6 +40,17 @@ export async function activate(context: vscode.ExtensionContext) {
       errorsCollection
     );
   }
+
+  // Quick Fixes Provider
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      "yaml",
+      new LiquidTestFixer(),
+      {
+        providedCodeActionKinds: LiquidTestFixer.providedCodeActionKinds,
+      }
+    )
+  );
 
   const statusBarItemRunTests = new StatusBarItem(context, credentials);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,10 +93,9 @@ export async function activate(context: vscode.ExtensionContext) {
         ...testObject.results,
         ...testObject.rollforwards,
       };
-
       if (testObject.reconciled) {
         // MESSAGE
-        let diagnosticMessage = `[${"Reconciled status"}] Expected: ${
+        let diagnosticMessage = `["Reconciled status"] Expected: ${
           testObject.reconciled.expected
         } (${typeof testObject.reconciled.expected}) | Got: ${
           testObject.reconciled.got
@@ -118,7 +117,7 @@ export async function activate(context: vscode.ExtensionContext) {
           range: diagnosticRange,
           message: diagnosticMessage,
           severity: vscode.DiagnosticSeverity.Error,
-          source: testObject.reconciled.got,
+          source: `${testName}.expectation.reconciled`, // to identify object in tree
           code: testName,
         };
         collectionArray.push(diagnostic);
@@ -168,12 +167,17 @@ export async function activate(context: vscode.ExtensionContext) {
           new vscode.Position(diagnosticLineNumber, highlightStartIndex),
           new vscode.Position(diagnosticLineNumber, highlighEndIndex)
         );
+        // result or rollforward ?
+        let itemType: string;
+        Object.keys(testObject.rollforwards).includes(itemName)
+          ? (itemType = "rollforward")
+          : (itemType = "result");
         // Create diagnostic object
         let diagnostic: types.DiagnosticObject = {
           range: diagnosticRange,
           message: diagnosticMessage,
           severity: vscode.DiagnosticSeverity.Error,
-          source: itemObject.got,
+          source: `${testName}.expectation.${itemType}.${itemName}`, // to identify object in tree
           code: testName,
         };
         collectionArray.push(diagnostic);

--- a/src/lib/quickFixes.ts
+++ b/src/lib/quickFixes.ts
@@ -1,0 +1,103 @@
+import * as vscode from "vscode";
+
+export class LiquidTestFixer implements vscode.CodeActionProvider {
+  public static readonly providedCodeActionKinds = [
+    vscode.CodeActionKind.QuickFix,
+  ];
+
+  public provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range | vscode.Selection,
+    context: vscode.CodeActionContext
+  ): vscode.CodeAction[] {
+    let quickFixes: vscode.CodeAction[] = [];
+    for (let diagnostic of context.diagnostics) {
+      // TODO We can use the diagnostic.code to define different types of fixes
+      // For example: "nothing" => non_existent_row => remove row
+      // For example: missing results => missing_row => add results in a new row
+      const expectedAndGot = this.getExpectedGotFromMessage(diagnostic.message);
+      const got = expectedAndGot[1].toString().trim();
+      let codeAction: vscode.CodeAction | undefined;
+      // if 'nothing', then we should remove the entire line
+      if (got === "nothing") {
+        codeAction = this.createRemoveRow(document, range);
+      } else {
+        codeAction = this.createReplaceFix(document, range, diagnostic);
+      }
+      if (codeAction) {
+        quickFixes.push(codeAction);
+      }
+    }
+    return quickFixes;
+  }
+
+  private createRemoveRow(document: vscode.TextDocument, range: vscode.Range) {
+    const fixDeleteRow = new vscode.CodeAction(
+      `Remove row`,
+      vscode.CodeActionKind.QuickFix
+    );
+    fixDeleteRow.edit = new vscode.WorkspaceEdit();
+    fixDeleteRow.edit.delete(
+      document.uri,
+      new vscode.Range(
+        new vscode.Position(range.start.line, 0),
+        new vscode.Position(range.start.line + 1, 0)
+      )
+    );
+    return fixDeleteRow;
+  }
+
+  // Create the QuickFix for each diagnostic
+  // Replace the "expected" value with the "got" value
+  private createReplaceFix(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+    diagnostic: vscode.Diagnostic
+  ): vscode.CodeAction | undefined {
+    const expectedAndGot = this.getExpectedGotFromMessage(diagnostic.message);
+    const got = expectedAndGot[1].toString().trim();
+    const rowContent = document.lineAt(range.start.line);
+    const indexContentStart = rowContent.text.match(/:/)?.index;
+    const indexContentEnd =
+      document.lineAt(range.start.line).text.split("").length + 1;
+    // no match ":" or element is empty after ":"
+    if (!indexContentStart || indexContentStart + 2 === indexContentEnd) {
+      return;
+    }
+    // Fix to replace content after ":" with the "got" value
+    const fixReplace = new vscode.CodeAction(
+      `Set to ${got}`,
+      vscode.CodeActionKind.QuickFix
+    );
+    fixReplace.edit = new vscode.WorkspaceEdit();
+    fixReplace.edit.replace(
+      document.uri,
+      new vscode.Range(
+        new vscode.Position(range.start.line, indexContentStart + 2),
+        new vscode.Position(range.start.line, indexContentEnd)
+      ),
+      got
+    );
+    return fixReplace;
+  }
+
+  // Return: [expected, got]
+  private getExpectedGotFromMessage(message: string): string[] {
+    const output = [];
+    const expectedRegex = /Expected:\s*([^(]+)/g;
+    const expectedMatch = message.match(expectedRegex);
+    if (expectedMatch) {
+      output.push(expectedMatch[0].replace("Expected: ", ""));
+    } else {
+      output.push("");
+    }
+    const gotRegex = /Got:\s*([^(]+)/g;
+    const gotMatch = message.match(gotRegex);
+    if (gotMatch) {
+      output.push(gotMatch[0].replace("Got: ", ""));
+    } else {
+      output.push("");
+    }
+    return output;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,6 +36,7 @@ export type DiagnosticObject = {
   severity: vscode.DiagnosticSeverity;
   source: string; // We store the expected value here
   tags?: vscode.DiagnosticTag[];
+  // relatedInformation?: vscode.DiagnosticRelatedInformation[];
 };
 
 export type StoredDiagnostic = {
@@ -48,6 +49,15 @@ export type StoredDiagnostic = {
   severity: number;
   source: string; // We store the expected value here
   tags?: any;
+  // relatedInformation?: [
+  //   {
+  //     range: [
+  //       { line: number; character: number },
+  //       { line: number; character: number }
+  //     ];
+  //     message: string;
+  //   }
+  // ];
 };
 
 // Convert the stored data back into a Diagnostic

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -146,8 +146,11 @@ export function filterFixedDiagnostics(
   let collectionArray: types.DiagnosticObject[] = [];
   for (let diagnosticStored of storedDiagnostics) {
     let testRow = currentDocument.getText(diagnosticStored.range);
-    let testRowExpectation = testRow.split(":")[1].trim();
-    if (testRowExpectation.toString() !== diagnosticStored.source.toString()) {
+    let testRowExpectation = testRow.split(":")[1];
+    if (
+      testRowExpectation &&
+      testRowExpectation.toString() !== diagnosticStored.source.toString()
+    ) {
       collectionArray.push(diagnosticStored);
     }
   }


### PR DESCRIPTION
## Description

- When the API response is "nothing", create a quick fix to remove the corresponding row
- When there is a difference between the "expected" and "got" values, create a quick fix to replace the content of the corresponding item with the value that we have "got" from the Liquid Test run

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [x] Changelog updated (if needed)
- [ ] Documentation updated (if needed)
