### PR TITLE
Remove auto-close dependency and integrate functionality directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.10.1]
+
+- Fix dependency on third-party auto-close extension that would block update of the extension on WSL by adding this functionality to the extension itself.
+
 ## [1.10.0]
 
 - Check if the included shared parts in the liquid code exists or not, and if they are added to the template configuration or not. Create diagnostics for this and also a quick-fix to add the shared part to the template configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
-## [1.10.1]
+## [1.10.2]
 
 - Fix dependency on third-party auto-close extension that would block update of the extension on WSL by adding this functionality to the extension itself.
+
+## [1.10.1]
+
+- Updated documentation
 
 ## [1.10.0]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",
@@ -2119,8 +2119,8 @@
       }
     },
     "node_modules/silverfin-cli": {
-      "version": "1.14.1",
-      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#75eb8242bd6b6998d8702c7b32d037dc464ed33e",
+      "version": "1.14.2",
+      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#36f38189c9787a211087dbc7cc367cf44a8252c6",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   ],
   "main": "./out/extension.js",
   "extensionDependencies": [
-    "redhat.vscode-yaml",
-    "formulahendry.auto-close-tag"
+    "redhat.vscode-yaml"
   ],
   "dependencies": {
     "@vscode/codicons": "^0.0.33",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { TemplateInformationViewProvider } from "./lib/sidebar/panelTemplateInfo
 import { TemplatePartsViewProvider } from "./lib/sidebar/panelTemplateParts";
 import StatusBarItem from "./lib/statusBar/statusBarItem";
 import * as diagnosticsUtils from "./utilities/diagnosticsUtils";
+import insertAutoCloseTag from "./lib/autoCloseTag";
 
 export async function activate(context: vscode.ExtensionContext) {
   // Initializers
@@ -22,6 +23,11 @@ export async function activate(context: vscode.ExtensionContext) {
   const liquidLinter = new LiquidLinter(outputChannel);
   const liquidTest = new LiquidTest(context, outputChannel);
   const liquidDiagnostics = new LiquidDiagnostics(context, outputChannel);
+
+  // Auto Close Tags
+  vscode.workspace.onDidChangeTextDocument((event) => {
+    insertAutoCloseTag(event);
+  });
 
   // References
   firmHandler.statusBarItem = statusBarItemRunTests;

--- a/src/lib/autoCloseTag.ts
+++ b/src/lib/autoCloseTag.ts
@@ -1,0 +1,230 @@
+"use strict";
+import * as vscode from "vscode";
+
+function insertAutoCloseTag(event: vscode.TextDocumentChangeEvent): void {
+  if (!event.contentChanges[0]) {
+    return;
+  }
+  let isRightAngleBracket = checkRightAngleBracket(event.contentChanges[0]);
+  if (!isRightAngleBracket && event.contentChanges[0].text !== "/") {
+    return;
+  }
+
+  let editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    return;
+  }
+
+  let config = vscode.workspace.getConfiguration(
+    "auto-close-tag",
+    editor.document.uri
+  );
+  if (!config.get<boolean>("enableAutoCloseTag", true)) {
+    return;
+  }
+
+  let languageId = editor.document.languageId;
+  let languages = config.get<string[]>("activationOnLanguage", ["*"]);
+  let disableOnLanguage = config.get<string[]>("disableOnLanguage", []);
+  if (
+    (languages.indexOf("*") === -1 && languages.indexOf(languageId) === -1) ||
+    disableOnLanguage.indexOf(languageId) !== -1
+  ) {
+    return;
+  }
+
+  let selection = editor.selection;
+  let originalPosition = selection.start.translate(0, 1);
+  let excludedTags = config.get<string[]>("excludedTags", []);
+  let isSublimeText3Mode = config.get<boolean>("SublimeText3Mode", false);
+  let enableAutoCloseSelfClosingTag = config.get<boolean>(
+    "enableAutoCloseSelfClosingTag",
+    true
+  );
+  let isFullMode = config.get<boolean>("fullMode");
+
+  if (
+    (isSublimeText3Mode || isFullMode) &&
+    event.contentChanges[0].text === "/"
+  ) {
+    let text = editor.document.getText(
+      new vscode.Range(new vscode.Position(0, 0), originalPosition)
+    );
+    let last2chars = "";
+    if (text.length > 2) {
+      last2chars = text.substr(text.length - 2);
+    }
+    if (last2chars === "</") {
+      let closeTag = getCloseTag(text, excludedTags);
+      if (closeTag) {
+        let nextChar = getNextChar(editor, originalPosition);
+        if (nextChar === ">") {
+          closeTag = closeTag.substr(0, closeTag.length - 1);
+        }
+        editor
+          .edit((editBuilder) => {
+            editBuilder.insert(originalPosition, closeTag);
+          })
+          .then(() => {
+            if (editor && nextChar === ">") {
+              editor.selection = moveSelectionRight(editor.selection, 1);
+            }
+          });
+      }
+    }
+  }
+
+  if (
+    ((!isSublimeText3Mode || isFullMode) && isRightAngleBracket) ||
+    (enableAutoCloseSelfClosingTag && event.contentChanges[0].text === "/")
+  ) {
+    let textLine = editor.document.lineAt(selection.start);
+    let text = textLine.text.substring(0, selection.start.character + 1);
+    let result =
+      /<([_a-zA-Z][a-zA-Z0-9:\-_.]*)(?:\s+[^<>]*?[^\s/<>=]+?)*?\s?(\/|>)$/.exec(
+        text
+      );
+    if (
+      result !== null &&
+      occurrenceCount(result[0], "'") % 2 === 0 &&
+      occurrenceCount(result[0], '"') % 2 === 0 &&
+      occurrenceCount(result[0], "`") % 2 === 0
+    ) {
+      if (result[2] === ">") {
+        if (excludedTags.indexOf(result[1].toLowerCase()) === -1) {
+          editor
+            .edit((editBuilder) => {
+              if (result && result[1]) {
+                editBuilder.insert(originalPosition, "</" + result[1] + ">");
+              }
+            })
+            .then(() => {
+              if (editor) {
+                editor.selection = new vscode.Selection(
+                  originalPosition,
+                  originalPosition
+                );
+              }
+            });
+        }
+      } else {
+        if (
+          textLine.text.length <= selection.start.character + 1 ||
+          textLine.text[selection.start.character + 1] !== ">"
+        ) {
+          // if not typing "/" just before ">", add the ">" after "/"
+          editor.edit((editBuilder) => {
+            if (config.get<boolean>("insertSpaceBeforeSelfClosingTag")) {
+              const spacePosition = originalPosition.translate(0, -1);
+              editBuilder.insert(spacePosition, " ");
+            }
+            editBuilder.insert(originalPosition, ">");
+          });
+        }
+      }
+    }
+  }
+}
+
+function checkRightAngleBracket(
+  contentChange: vscode.TextDocumentContentChangeEvent
+): boolean {
+  return (
+    contentChange.text === ">" ||
+    checkRightAngleBracketInVSCode1p8(contentChange)
+  );
+}
+
+function checkRightAngleBracketInVSCode1p8(
+  contentChange: vscode.TextDocumentContentChangeEvent
+): boolean {
+  return (
+    contentChange.text.endsWith(">") &&
+    contentChange.range.start.character === 0 &&
+    contentChange.range.start.line === contentChange.range.end.line &&
+    !contentChange.range.end.isEqual(new vscode.Position(0, 0))
+  );
+}
+
+function insertCloseTag(): void {
+  let editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    return;
+  }
+
+  let selection = editor.selection;
+  let originalPosition = selection.start;
+  let config = vscode.workspace.getConfiguration(
+    "auto-close-tag",
+    editor.document.uri
+  );
+  let excludedTags = config.get<string[]>("excludedTags", []);
+  let text = editor.document.getText(
+    new vscode.Range(new vscode.Position(0, 0), originalPosition)
+  );
+  if (text.length > 2) {
+    let closeTag = getCloseTag(text, excludedTags);
+    if (closeTag) {
+      editor.edit((editBuilder) => {
+        editBuilder.insert(originalPosition, closeTag);
+      });
+    }
+  }
+}
+
+function getNextChar(
+  editor: vscode.TextEditor,
+  position: vscode.Position
+): string {
+  let nextPosition = position.translate(0, 1);
+  let text = editor.document.getText(new vscode.Range(position, nextPosition));
+  return text;
+}
+
+function getCloseTag(text: string, excludedTags: string[]): string {
+  let regex =
+    /<(\/?[_a-zA-Z][a-zA-Z0-9:\-_.]*)(?:\s+[^<>]*?[^\s/<>=]+?)*?\s?>/g;
+  let result = null;
+  let stack = [];
+  while ((result = regex.exec(text)) !== null) {
+    let isStartTag = result[1].substr(0, 1) !== "/";
+    let tag = isStartTag ? result[1] : result[1].substr(1);
+    if (excludedTags.indexOf(tag.toLowerCase()) === -1) {
+      if (isStartTag) {
+        stack.push(tag);
+      } else if (stack.length > 0) {
+        let lastTag = stack[stack.length - 1];
+        if (lastTag === tag) {
+          stack.pop();
+        }
+      }
+    }
+  }
+  if (stack.length > 0) {
+    let closeTag = stack[stack.length - 1];
+    if (text.substr(text.length - 2) === "</") {
+      return closeTag + ">";
+    }
+    if (text.substr(text.length - 1) === "<") {
+      return "/" + closeTag + ">";
+    }
+    return "</" + closeTag + ">";
+  } else {
+    return "";
+  }
+}
+
+function moveSelectionRight(
+  selection: vscode.Selection,
+  shift: number
+): vscode.Selection {
+  let newPosition = selection.active.translate(0, shift);
+  let newSelection = new vscode.Selection(newPosition, newPosition);
+  return newSelection;
+}
+
+function occurrenceCount(source: string, find: string): number {
+  return source.split(find).length - 1;
+}
+
+export default insertAutoCloseTag;


### PR DESCRIPTION
## Description

Removes the dependency from the third-party auto-close extension and integrate the functionality directly as it blocks update of the extension on WSL.

Reason seems to be that the 3rd party extension has a setting to be running on Windows instead of WSL, which is causing the issue. 

Fixes #23

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Changelog updated (if needed)
- [ ] Documentation updated (if needed)
