### PR TITLE
fix running testName when moving across templates + hide development sections if no default firm is set or no test data exists for the template + fix development mode platform updates failing for shared parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to the "silverfin-development-toolkit" extension will be doc
 - Testname visually dissapeared when moving across templates after the development mode for liquid tests was activated, now this will keep being displayed
 - When no liquid tests exist or are not possible (i.e. shared parts), then we'll hide the liquid test development sections
 - Development mode - platform was not working for shared parts
+- Add default firm to text of "Development mode - platform" so users are reminded to which firm they're pushing
+- Don't enable development mode if no default firm is set + add message to inform the user that they still need to set one
 
 ## [1.13.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.13.2]
+
+- Testname visually dissapeared when moving across templates after the development mode for liquid tests was activated, now this will keep being displayed
+- When no liquid tests exist or are not possible (i.e. shared parts), then we'll hide the liquid test development sections
+- Development mode - platform was not working for shared parts
+
 ## [1.13.1]
 
 - Remove conflicting keybinding for "Silverfin: verify liquid syntax (linter)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.13.0",
+  "version": "1.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.13.0",
+      "version": "1.13.2",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",
@@ -723,6 +723,14 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2119,14 +2127,15 @@
       }
     },
     "node_modules/silverfin-cli": {
-      "version": "1.20.4",
-      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#f7c99c4dbc55f18ad86aaa87fcc7ebf1c53c5f71",
+      "version": "1.22.0",
+      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#a704aed5333ab4a01e0c76a248a654a63d96da1e",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.1",
         "chalk": "4.1.2",
         "command-exists": "^1.2.9",
         "commander": "^9.4.0",
+        "consola": "^3.2.3",
         "is-wsl": "^2.2.0",
         "open": "^8.4.0",
         "prompt-sync": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/lib/sidebar/panelTests.ts
+++ b/src/lib/sidebar/panelTests.ts
@@ -3,12 +3,14 @@ import * as types from "../../lib/types";
 import * as templateUtils from "../../utilities/templateUtils";
 import * as utils from "../../utilities/utils";
 import * as panelUtils from "./panelUtils";
+const { firmCredentials } = require("silverfin-cli/lib/api/firmCredentials");
 
 export class TestsViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = "development";
   public _view?: vscode.WebviewView;
   public devModeStatus: "active" | "inactive" = "inactive";
   public lockedHandle!: string;
+  public firmIdStored: string | undefined;
   public devModeOption: "liquid-tests" | "liquid-updates" = "liquid-tests";
   public testDetails!: types.TestRunDetails;
   private devModeLiquidInfo =
@@ -50,6 +52,7 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
     const gridLayout = `grid-template-columns="2fr 1fr"`;
     const disabledLabel = this.clickableButtons() ? "" : "disabled";
     const disabledReverseLabel = this.clickableButtons() ? "disabled" : "";
+    this.firmIdStored = await firmCredentials.getDefaultFirmId();
     const liquidTestsRows = testNames.map((testName: string) => {
       return /*html*/ `
             <vscode-data-grid-row grid-columns="2">
@@ -163,7 +166,9 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
           <vscode-button appearance="icon" class="dev-mode-tests" title="Activate" data-status="active" ${disabledLabel}>
             <i class="codicon codicon-debug-start"></i>
           </vscode-button>
-          <vscode-button appearance="icon" class="dev-mode-tests" title="Deactivate" data-status="inactive" ${disabledReverseLabel}>
+          <vscode-button appearance="icon" class="dev-mode-tests" title="Deactivate" data-status="inactive" ${
+            !this.firmIdStored ? "disabled" : ""
+          } ${disabledReverseLabel}>
             <i class="codicon codicon-stop-circle"></i>
           </vscode-button>
         </vscode-data-grid-cell>
@@ -189,13 +194,19 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
       /* html */
       `<vscode-data-grid-row grid-columns="2">
         <vscode-data-grid-cell grid-column="1">
-          Push updates to Silverfin (on save)
+          ${
+            this.firmIdStored
+              ? `Push updates to Silverfin in firm ${this.firmIdStored}`
+              : "You need to add a default firm before you can activate development mode to push automatically to Silverfin"
+          } <i>(on save)</i>
         </vscode-data-grid-cell>
         <vscode-data-grid-cell grid-column="2" class="vs-actions">
           <vscode-button appearance="icon" class="dev-mode-liquid" title="Activate" data-status="active" ${disabledLabel}>
             <i class="codicon codicon-debug-start"></i>
           </vscode-button>
-          <vscode-button appearance="icon" class="dev-mode-liquid" title="Deactivate" data-status="inactive" ${disabledReverseLabel}>
+          <vscode-button appearance="icon" class="dev-mode-liquid" title="Deactivate" data-status="inactive" ${
+            !this.firmIdStored ? "disabled" : ""
+          } ${disabledReverseLabel}>
             <i class="codicon codicon-stop-circle"></i>
           </vscode-button>
         </vscode-data-grid-cell>
@@ -220,9 +231,13 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
     let htmlBody =
       /*html*/
       `<vscode-data-grid aria-label="liquid tests" ${gridLayout}>
-        ${this.lockedHandle || testNames.length > 0 ? devTestBlock : ""}
+        ${
+          this.firmIdStored && (this.lockedHandle || testNames.length > 0)
+            ? devTestBlock
+            : ""
+        }
         ${devLiquidBlock}
-        ${testNames.length > 0 ? liquidTestsBlock : ""}
+        ${this.firmIdStored && testNames.length > 0 ? liquidTestsBlock : ""}
       </vscode-data-grid>`;
 
     let htmlContent = panelUtils.htmlContainer(
@@ -273,7 +288,7 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
   }
 
   private clickableButtons() {
-    if (this.devModeStatus === "active") {
+    if (!this.firmIdStored || this.devModeStatus === "active") {
       return false;
     }
     this.lockedHandle = "";

--- a/src/lib/sidebar/panelTests.ts
+++ b/src/lib/sidebar/panelTests.ts
@@ -101,10 +101,16 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
           ${liquidTestsRows.join("")}`
         : "";
 
+    // Show options of tests if not running, but hardcode to the current test if running across templates
+    const createTestOption = (testName: string, selected: boolean) => {
+      return /*html*/ `<vscode-option value="${testName}" ${
+        selected ? "selected" : ""
+      }>${testName}</vscode-option>`;
+    };
+
     const testNameOptions = testNames.map((testName: string) => {
-      const selected =
-        this.testDetails?.testName === testName ? "selected" : "";
-      return /*html*/ `<vscode-option value="${testName}" ${selected}>${testName}</vscode-option>`;
+      const selected = this.testDetails?.testName === testName ? true : false;
+      return createTestOption(testName, selected);
     });
 
     const htmlOptionValues = [
@@ -136,7 +142,11 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
         <vscode-data-grid-cell grid-column="1">
           <div class="dropdown-container">
             <vscode-dropdown class="dropdown-truncate" id="test-selection" ${disabledLabel}>
-              ${testNameOptions.join("")}
+              ${
+                this.testDetails?.testName
+                  ? createTestOption(this.testDetails?.testName, true)
+                  : testNameOptions.join("")
+              }
             </vscode-dropdown>
           </div>
         </vscode-data-grid-cell>
@@ -210,9 +220,9 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
     let htmlBody =
       /*html*/
       `<vscode-data-grid aria-label="liquid tests" ${gridLayout}>
-        ${devTestBlock}
+        ${this.lockedHandle || testNames.length > 0 ? devTestBlock : ""}
         ${devLiquidBlock}
-        ${liquidTestsBlock}
+        ${testNames.length > 0 ? liquidTestsBlock : ""}
       </vscode-data-grid>`;
 
     let htmlContent = panelUtils.htmlContainer(
@@ -267,6 +277,12 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
       return false;
     }
     this.lockedHandle = "";
+    this.testDetails = {
+      templateHandle: "",
+      testName: "",
+      previewOnly: false,
+      htmlType: "none",
+    };
     return true;
   }
 

--- a/src/lib/templateUpdater.ts
+++ b/src/lib/templateUpdater.ts
@@ -34,7 +34,7 @@ export class TemplateUpdater {
         updateFunction = sfCli.publishReconciliationByHandle;
         break;
       case "sharedPart":
-        updateFunction = sfCli.publishSharedPartByHandle;
+        updateFunction = sfCli.publishSharedPartByName;
         break;
       case "exportFile":
         updateFunction = sfCli.publishExportFileByName;


### PR DESCRIPTION
## Description

- Testname visually dissapeared when moving across templates after the development mode for liquid tests was activated, now this will keep being displayed
- When no liquid tests exist or are not possible (i.e. shared parts), then we'll hide the liquid test development sections
- Development mode - platform was not working for shared parts
- Add default firm to text of "Development mode - platform" so users are reminded to which firm they're pushing
- Don't enable development mode if no default firm is set + add message to inform the user that they still need to set one


## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- [x] README updated (if needed)
- [x] Version updated (if needed)
- [x] Changelog updated (if needed)
- [x] Documentation updated (if needed)
