### PR TITLE
Fix disabled start button in development mode when a default firm is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.13.3]
+
+- Fix issue where 'Start' buttons for development mode was disabled even though the default firm was set
+
 ## [1.13.2]
 
 - Testname visually dissapeared when moving across templates after the development mode for liquid tests was activated, now this will keep being displayed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/lib/sidebar/panelTests.ts
+++ b/src/lib/sidebar/panelTests.ts
@@ -288,7 +288,7 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
   }
 
   private clickableButtons() {
-    if (!this.firmIdStored || this.devModeStatus === "active") {
+    if (this.devModeStatus === "active") {
       return false;
     }
     this.lockedHandle = "";


### PR DESCRIPTION
## Description

The start button for dev mode panel was disabled, even when there was a default firm set. 

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- [x] README updated (if needed)
- [x] Version updated (if needed)
- [x] Changelog updated (if needed)
- [x] Documentation updated (if needed)
