### PR TITLE
Fix: Shared Parts quick fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.13.7",
+      "version": "1.13.8",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",
@@ -568,12 +568,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -708,6 +715,17 @@
       "version": "1.1.4",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "license": "MIT"
@@ -788,6 +806,14 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
@@ -1165,14 +1191,15 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1180,6 +1207,19 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -1609,6 +1649,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
@@ -1942,6 +2001,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "dev": true,
@@ -2127,11 +2191,11 @@
       }
     },
     "node_modules/silverfin-cli": {
-      "version": "1.22.0",
-      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#a704aed5333ab4a01e0c76a248a654a63d96da1e",
+      "version": "1.24.2",
+      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#a322c066fe5a9c90d86a97fc23eae98b99a87ab3",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.26.1",
+        "axios": "^1.6.2",
         "chalk": "4.1.2",
         "command-exists": "^1.2.9",
         "commander": "^9.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/lib/quickFixes/liquidQuickFixes.ts
+++ b/src/lib/quickFixes/liquidQuickFixes.ts
@@ -17,7 +17,7 @@ export default class LiquidQuickFixes implements vscode.CodeActionProvider {
       if (!details) {
         continue;
       }
-      let identifier = `addSharedPart.${details.sharedPartName}.${details.templateHandle}.${details.firmId}`;
+      let identifier = `addSharedPart.${details.sharedPartName}.${details.templateHandle}.${details.templateType}.${details.firmId}`;
       let title = `${details.missing ? "Create and add" : "Add"} shared part "${
         details.sharedPartName
       }" to template "${details.templateHandle}" in firm "${details.firmId}"`;
@@ -40,21 +40,25 @@ export default class LiquidQuickFixes implements vscode.CodeActionProvider {
     const sharedPartRegex = /Shared part "([^"]+)"/;
     const templateRegex = /template "([^"]+)"/;
     const firmIdRegex = /firm id "([^"]+)"/;
+    const templateTypeRegex = /template type: "([^"]+)"/;
     const missingRegex = /not exist/;
     const sharedPartMatch = message.match(sharedPartRegex);
     const templateMatch = message.match(templateRegex);
     const firmIdMatch = message.match(firmIdRegex);
     const missingMatch = message.match(missingRegex);
+    const templateTypeMatch = message.match(templateTypeRegex);
     const sharedPartName = sharedPartMatch ? sharedPartMatch[1] : undefined;
     const templateHandle = templateMatch ? templateMatch[1] : undefined;
     const firmId = firmIdMatch ? firmIdMatch[1] : undefined;
+    const templateType = templateTypeMatch ? templateTypeMatch[1] : undefined;
     const missing = missingMatch ? true : false;
-    if (!sharedPartName || !templateHandle || !firmId) {
+    if (!sharedPartName || !templateHandle || !templateType || !firmId) {
       return undefined;
     }
     return {
       sharedPartName: sharedPartName,
       templateHandle: templateHandle,
+      templateType: templateType,
       firmId: firmId,
       missing: missing,
     };


### PR DESCRIPTION
## Description

- Bump silverfin-cli version to support account templates. Solve issue with development mode not updating Account Templates.
- Currently, the quick fix to add a shared part only works for reconciliations. Extend it's support to other template types (export files and account templates)
  - Still not looking into shared parts to identify nested used of them.

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Changelog updated (if needed)
- [ ] Documentation updated (if needed)
