### PR TITLE
Create Text Parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.14.0]
+
+- New button in side-bar to create text parts. Also, automatically checks if part has been deleted to update it's reference in the corresponding config.json file
+
 ## [1.13.9]
 
 - Update liquid testing JSON schema for validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.13.9",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.13.9",
+      "version": "1.14.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.13.9",
+  "version": "1.14.0",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,17 +173,19 @@ export async function activate(context: vscode.ExtensionContext) {
       templatePartsProvider
     )
   );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("template-parts-panel.refresh", () => {
+      if (!templatePartsProvider._view) {
+        return;
+      }
+      templatePartsProvider.setContent(templatePartsProvider._view);
+    })
+  );
   vscode.window.onDidChangeActiveTextEditor(() => {
-    if (!templatePartsProvider._view) {
-      return;
-    }
-    templatePartsProvider.setContent(templatePartsProvider._view);
+    vscode.commands.executeCommand("template-parts-panel.refresh");
   });
   vscode.workspace.onDidSaveTextDocument(() => {
-    if (!templatePartsProvider._view) {
-      return;
-    }
-    templatePartsProvider.setContent(templatePartsProvider._view);
+    vscode.commands.executeCommand("template-parts-panel.refresh");
   });
   // Template Info
   const templateInfoProvider = new TemplateInformationViewProvider(
@@ -195,17 +197,19 @@ export async function activate(context: vscode.ExtensionContext) {
       templateInfoProvider
     )
   );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("template-info-panel.refresh", () => {
+      if (!templateInfoProvider._view) {
+        return;
+      }
+      templateInfoProvider.setContent(templateInfoProvider._view);
+    })
+  );
   vscode.window.onDidChangeActiveTextEditor(() => {
-    if (!templateInfoProvider._view) {
-      return;
-    }
-    templateInfoProvider.setContent(templateInfoProvider._view);
+    vscode.commands.executeCommand("template-info-panel.refresh");
   });
   vscode.workspace.onDidSaveTextDocument(() => {
-    if (!templateInfoProvider._view) {
-      return;
-    }
-    templateInfoProvider.setContent(templateInfoProvider._view);
+    vscode.commands.executeCommand("template-info-panel.refresh");
   });
   // Liquid Tests
   const testsProvider = new TestsViewProvider(
@@ -219,17 +223,19 @@ export async function activate(context: vscode.ExtensionContext) {
       testsProvider
     )
   );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("tests-panel.refresh", () => {
+      if (!testsProvider._view) {
+        return;
+      }
+      testsProvider.setContent(testsProvider._view);
+    })
+  );
   vscode.window.onDidChangeActiveTextEditor(() => {
-    if (!testsProvider._view) {
-      return;
-    }
-    testsProvider.setContent(testsProvider._view);
+    vscode.commands.executeCommand("tests-panel.refresh");
   });
   vscode.workspace.onDidSaveTextDocument(() => {
-    if (!testsProvider._view) {
-      return;
-    }
-    testsProvider.setContent(testsProvider._view);
+    vscode.commands.executeCommand("tests-panel.refresh");
   });
   // Firm Info
   const firmInfoProvider = new FirmViewProvider(context.extensionUri);
@@ -239,20 +245,7 @@ export async function activate(context: vscode.ExtensionContext) {
       firmInfoProvider
     )
   );
-  vscode.window.onDidChangeActiveTextEditor(() => {
-    if (!firmInfoProvider._view) {
-      return;
-    }
-    firmInfoProvider.setContent(firmInfoProvider._view);
-  });
-  vscode.workspace.onDidSaveTextDocument(() => {
-    if (!firmInfoProvider._view) {
-      return;
-    }
-    firmInfoProvider.setContent(firmInfoProvider._view);
-  });
   // command that can be used to force a refresh of the firms panel
-  // used when the user changes the firm id to refresh the Active label
   context.subscriptions.push(
     vscode.commands.registerCommand("firm-panel.refresh", () => {
       if (!firmInfoProvider._view) {
@@ -261,6 +254,12 @@ export async function activate(context: vscode.ExtensionContext) {
       firmInfoProvider.setContent(firmInfoProvider._view);
     })
   );
+  vscode.window.onDidChangeActiveTextEditor(() => {
+    vscode.commands.executeCommand("firm-panel.refresh");
+  });
+  vscode.workspace.onDidSaveTextDocument(() => {
+    vscode.commands.executeCommand("firm-panel.refresh");
+  });
 
   // Auto Close Tags
   vscode.workspace.onDidChangeTextDocument((event) => {

--- a/src/lib/sidebar/main.ts
+++ b/src/lib/sidebar/main.ts
@@ -36,6 +36,7 @@ function main() {
   runTestButton();
   devModeLiquidButton();
   devModeTestsButton();
+  createNewPartButton();
 }
 
 // Add event listener to all buttons with class "open-file"
@@ -183,5 +184,22 @@ function postMessageDevModeTests(
     status: dataStatus,
     testName: dataTestSelection,
     htmlType: dataHtmlMode,
+  });
+}
+
+// Add event listener to button with class "create-new-part"
+function createNewPartButton() {
+  const buttons = document.getElementsByClassName("create-new-part");
+  const buttonsArray = Array.from(buttons);
+  buttonsArray.forEach((element) => {
+    element?.addEventListener("click", () => {
+      postMessageCreateNewPart();
+    });
+  });
+}
+
+function postMessageCreateNewPart() {
+  vscode.postMessage({
+    type: "create-new-part",
   });
 }

--- a/src/lib/sidebar/panelTemplateParts.ts
+++ b/src/lib/sidebar/panelTemplateParts.ts
@@ -37,8 +37,9 @@ export class TemplatePartsViewProvider implements vscode.WebviewViewProvider {
     const configData = await templateUtils.getTemplateConfigData();
     let htmlContent = "";
 
-    // Reconciliations
+    // Templates
     if (configData && "text_parts" in configData) {
+      templateUtils.removeDeletedParts();
       htmlContent = await this.htmlPartsTemplates(
         firmId,
         configData,

--- a/src/utilities/templateUtils.ts
+++ b/src/utilities/templateUtils.ts
@@ -99,15 +99,15 @@ export async function getTemplateConfigPath() {
   if (!vscode.window.activeTextEditor) {
     return false;
   }
-  const templateHanlde = getTemplateHandle();
-  if (!templateHanlde) {
+  const templateHandle = getTemplateHandle();
+  if (!templateHandle) {
     return false;
   }
   const filePath = posix.resolve(
     vscode.window.activeTextEditor.document.uri.path
   );
   const fileParts = filePath.split(posix.sep);
-  const indexCheck = (element: string) => element === templateHanlde;
+  const indexCheck = (element: string) => element === templateHandle;
   const index = fileParts.findIndex(indexCheck);
   if (index === -1) {
     return false;


### PR DESCRIPTION
## Description

Until now, new text parts have to be manually created, while also adding it's corresponding reference inside `config.json`
Added a new button to the side bar to create text parts.
Also, check if text parts where manually deleted to update the corresponding config.json

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [X] Changelog updated (if needed)
- [ ] Documentation updated (if needed)
