### PR TITLE
Dev-mode: disable buttons work individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.14.1]
+
+- Side-bar. Development-mode. When one of the options in enabeled (local or platform), only show as enabled the button to stop that specific action.
+
 ## [1.14.0]
 
 - New button in side-bar to create text parts. Also, automatically checks if part has been deleted to update it's reference in the corresponding config.json file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/lib/sidebar/panelTests.ts
+++ b/src/lib/sidebar/panelTests.ts
@@ -52,7 +52,22 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
     const gridLayout = `grid-template-columns="2fr 1fr"`;
     this.firmIdStored = await firmCredentials.getDefaultFirmId();
     const disabledLabel = this.clickableButtons() ? "" : "disabled";
-    const disabledReverseLabel = this.clickableButtons() ? "disabled" : "";
+    let disabledStopTestsLabel = "disabled";
+    let disabledStopUpdatesLabel = "disabled";
+    if (
+      this.firmIdStored &&
+      !this.clickableButtons() &&
+      this.devModeOption === "liquid-tests"
+    ) {
+      disabledStopTestsLabel = "";
+    }
+    if (
+      this.firmIdStored &&
+      !this.clickableButtons() &&
+      this.devModeOption === "liquid-updates"
+    ) {
+      disabledStopUpdatesLabel = "";
+    }
     const liquidTestsRows = testNames.map((testName: string) => {
       return /*html*/ `
             <vscode-data-grid-row grid-columns="2">
@@ -166,9 +181,7 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
           <vscode-button appearance="icon" class="dev-mode-tests" title="Activate" data-status="active" ${disabledLabel}>
             <i class="codicon codicon-debug-start"></i>
           </vscode-button>
-          <vscode-button appearance="icon" class="dev-mode-tests" title="Deactivate" data-status="inactive" ${
-            !this.firmIdStored ? "disabled" : ""
-          } ${disabledReverseLabel}>
+          <vscode-button appearance="icon" class="dev-mode-tests" title="Deactivate" data-status="inactive" ${disabledStopTestsLabel}>
             <i class="codicon codicon-stop-circle"></i>
           </vscode-button>
         </vscode-data-grid-cell>
@@ -204,9 +217,7 @@ export class TestsViewProvider implements vscode.WebviewViewProvider {
           <vscode-button appearance="icon" class="dev-mode-liquid" title="Activate" data-status="active" ${disabledLabel}>
             <i class="codicon codicon-debug-start"></i>
           </vscode-button>
-          <vscode-button appearance="icon" class="dev-mode-liquid" title="Deactivate" data-status="inactive" ${
-            !this.firmIdStored ? "disabled" : ""
-          } ${disabledReverseLabel}>
+          <vscode-button appearance="icon" class="dev-mode-liquid" title="Deactivate" data-status="inactive" ${disabledStopUpdatesLabel}>
             <i class="codicon codicon-stop-circle"></i>
           </vscode-button>
         </vscode-data-grid-cell>


### PR DESCRIPTION
## Description

Now, when you activate one of the development modes, both "stop" buttons will be active.
Update to make them work individually, so only the one from the process running is enabled each time

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [X] Changelog updated (if needed)
- [ ] Documentation updated (if needed)
