### PR TITLE
Bump silverfin-cli version to dependency with partner API updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.15.6]
+
+- Bump silverfin-cli version to version that supports the partner API
+- Bump dependencies after security audit
+
 ## [1.15.5]
 
 - Fix for search and replace and dev-mode. So far, dev-mode was only working with the ActiveTextEditor. Changed to work on any saved file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.15.4",
+      "version": "1.15.5",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",
@@ -1640,9 +1640,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -2749,8 +2749,8 @@
       }
     },
     "node_modules/silverfin-cli": {
-      "version": "1.25.7",
-      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#6c4cd1782c4d59e82927bdd925098ac8d344b82c",
+      "version": "1.26.3",
+      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#8a27dbb0bac48236bc5c7b3fd64b4024c4aab7e1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.15.5",
+  "version": "1.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.15.5",
+      "version": "1.15.6",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.15.5",
+  "version": "1.15.6",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/lib/templateUpdater.ts
+++ b/src/lib/templateUpdater.ts
@@ -49,7 +49,7 @@ export default class TemplateUpdater {
     const functionName = updateFunction.name;
     this.extensionLogger.log("Updating template", { parameters, functionName });
 
-    const updated = await updateFunction(this.firmId, templateHandle, message);
+    const updated = await updateFunction("firm", this.firmId, templateHandle, message);
     this.extensionLogger.log("Template updated?", {
       parameters,
       functionName,


### PR DESCRIPTION
## Description

The newest silverfin-cli version contains a lot of updates to support the partner API, so bumping this and fixing to support the new version. 

Also did a bump of dependency versions that had known security vulnerabilities.

### TESTED ✅ 
1. Panels for reconciliation texts, shared parts, account templates, export files still showing list of parts
2. Panels for template information, firms still displaying info
3. Panel for development mode still working
4. Panel for liquid testing still working
5. Authorization through extension still working
6. Commands from command panel
  * Run liquid tests (with & without output)
  * Set default firm
  * Erase stored liquid test details
  * Authorize firm

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] README updated (if needed)
- [x] Version updated (if needed)
- [x] Changelog updated (if needed)
- [x] Documentation updated (if needed)
