### PR TITLE
Fix so YAML is still parsed for large test suites + clear diagnostics when closing VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.16.3]
+
+- Some really large YAMLs contained too many aliases that reached the limit and caused the document to no longer be parsed. Increased the limit so it aligns with the limit in the CLI and it can support very large YAMLs
+- When restarting the VS Code, the "Problems" panel for a template gets cleared so previous liquid testing errors don't keep popping up there
+
 ## [1.16.2]
 
 - Fix shared parts management from sidebar

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.16.2",
+      "version": "1.16.3",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/lib/diagnostics/diagnosticCollectionsHandler.ts
+++ b/src/lib/diagnostics/diagnosticCollectionsHandler.ts
@@ -126,12 +126,5 @@ export default class DiagnosticCollectionsHandler {
         liquidTestCollection
       );
     }
-
-    // When a new file is opened for the first time. Load the Diagnostic stored from previous runs
-    extensionContext.subscriptions.push(
-      vscode.workspace.onDidOpenTextDocument(async (currentDocument) => {
-        this.loadStoredDiagnostics(currentDocument, liquidTestCollection);
-      })
-    );
   }
 }

--- a/src/lib/liquidTestHandler.ts
+++ b/src/lib/liquidTestHandler.ts
@@ -80,6 +80,7 @@ export default class LiquidTestHandler {
     htmlRenderMode: types.htmlRenderModes
   ) {
     try {
+      this.setStatusBarRunning();
       this.firmId = await this.firmHandler.setFirmID();
       this.templateHandle = templateHandle;
       this.outputLog("New test run", {
@@ -89,7 +90,6 @@ export default class LiquidTestHandler {
         htmlRenderMode
       });
       // Test Run
-      this.setStatusBarRunning();
       let response: types.ResponseObject =
         await SilverfinToolkit.liquidTestRunner.runTests(
           this.firmId,
@@ -633,13 +633,6 @@ export default class LiquidTestHandler {
           );
         }
       )
-    );
-
-    // Clear Diagnostic Collection of all files when hard-closing / reloading VS code
-    extensionContext.subscriptions.push(
-      vscode.workspace.onDidCloseTextDocument((document) => {
-        extensionContext.globalState.update(document.uri.toString(), undefined);
-      })
     );
   }
 }

--- a/src/lib/sidebar/main.ts
+++ b/src/lib/sidebar/main.ts
@@ -11,7 +11,7 @@ import {
   vsCodeDropdown,
   vsCodeLink,
   vsCodeOption,
-  vsCodeTag,
+  vsCodeTag
 } from "@vscode/webview-ui-toolkit";
 
 provideVSCodeDesignSystem().register(
@@ -58,7 +58,7 @@ function openFileButton() {
 function postMessageOpenFile(dataValue: string | null) {
   vscode.postMessage({
     type: "open-file",
-    value: dataValue,
+    value: dataValue
   });
 }
 
@@ -76,7 +76,7 @@ function authNewFirmButton() {
 
 function postMessageAuthNewFirm() {
   vscode.postMessage({
-    type: "auth-new-firm",
+    type: "auth-new-firm"
   });
 }
 
@@ -94,7 +94,7 @@ function setDefaultFirmButton() {
 
 function postMessageSetDefaultFirm() {
   vscode.postMessage({
-    type: "set-active-firm",
+    type: "set-active-firm"
   });
 }
 
@@ -130,7 +130,7 @@ function postMessageRunTest(
     templateType: dataTemplateType,
     templateHandle: dataTemplateHandle,
     testName: dataTestName,
-    htmlType: dataHtmlType,
+    htmlType: dataHtmlType
   });
 }
 
@@ -149,7 +149,7 @@ function devModeLiquidButton() {
 function postMessageDevModeLiquid(dataStatus: string | null) {
   vscode.postMessage({
     type: "dev-mode-liquid",
-    status: dataStatus,
+    status: dataStatus
   });
 }
 
@@ -185,7 +185,7 @@ function postMessageDevModeTests(
     type: "dev-mode-tests",
     status: dataStatus,
     testName: dataTestSelection,
-    htmlType: dataHtmlMode,
+    htmlType: dataHtmlMode
   });
 }
 
@@ -202,7 +202,7 @@ function createNewPartButton() {
 
 function postMessageCreateNewPart() {
   vscode.postMessage({
-    type: "create-new-part",
+    type: "create-new-part"
   });
 }
 
@@ -218,7 +218,7 @@ function addSharedPartButton() {
 
 function postMessageAddSharedPart() {
   vscode.postMessage({
-    type: "add-shared-part",
+    type: "add-shared-part"
   });
 }
 
@@ -234,6 +234,6 @@ function removeSharedPartButton() {
 
 function postMessageRemoveSharedPart() {
   vscode.postMessage({
-    type: "remove-shared-part",
+    type: "remove-shared-part"
   });
 }


### PR DESCRIPTION
## Description

- Some really large YAMLs contained too many aliases that reached the limit and caused the document to no longer be parsed. Increased the limit so it aligns with the limit in the CLI and it can support very large YAMLs
- When restarting the VS Code, the "Problems" panel for a template gets cleared so previous liquid testing errors don't keep popping up there

Fixes #50 

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- [x] README updated (if needed)
- [x] Version updated (if needed)
- [x] Changelog updated (if needed)
- [x] Documentation updated (if needed)
