### PR TITLE
Fix so different expectation errors in liquid test results are added correctly from quick fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.16.5]
+
+- Fix so different expectation errors in liquid test results are added correctly from quick fixes
+   
 ## [1.16.4]
 
 - Fix issue where a wrong list of shared parts was shown if the current default firm ID did not exist in the config of a template

--- a/package-lock.json
+++ b/package-lock.json
@@ -1991,12 +1991,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "peer": true
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2105,18 +2099,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -2573,18 +2555,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.16.4",
+      "version": "1.16.5",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",
@@ -2707,9 +2707,8 @@
       }
     },
     "node_modules/silverfin-cli": {
-      "version": "1.26.9",
-      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#5353cef98fb9faceac7a6ae408ce9bf3edd96fff",
-      "license": "MIT",
+      "version": "1.26.10",
+      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#68e168bead5afef8bdeef2a3cc74bd3542b9945a",
       "dependencies": {
         "axios": "^1.6.2",
         "chalk": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/lib/diagnostics/diagnosticCollectionsHandler.ts
+++ b/src/lib/diagnostics/diagnosticCollectionsHandler.ts
@@ -94,9 +94,7 @@ export default class DiagnosticCollectionsHandler {
     // Open Diagnostic Stored in Global State
     let storedDiagnostics: types.StoredDiagnostic[] | undefined =
       await extensionContext.globalState.get(currentDocument.uri.toString());
-    this.extensionLogger.log(
-      `loaded: ${JSON.stringify(currentDocument.fileName)}`
-    );
+
     if (storedDiagnostics) {
       // Recreate Diagnostic Objects
       let collectionArray: types.DiagnosticObject[] = [];

--- a/src/lib/quickFixes/liquidTestsQuickFixes.ts
+++ b/src/lib/quickFixes/liquidTestsQuickFixes.ts
@@ -1,10 +1,14 @@
 import * as vscode from "vscode";
 import * as diagnosticsUtils from "../../utilities/diagnosticsUtils";
+import ExtensionLoggerWrapper from "../outputChannels/extensionLoggerWrapper";
 
 export default class LiquidTestQuickFixes implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [
-    vscode.CodeActionKind.QuickFix,
+    vscode.CodeActionKind.QuickFix
   ];
+  private extensionLogger: ExtensionLoggerWrapper = new ExtensionLoggerWrapper(
+    "liquidTestsQuickFixes"
+  );
 
   // Provide the QuickFixes for each diagnostic
   // It looks at the existing collection of diagnostics in the context
@@ -15,16 +19,15 @@ export default class LiquidTestQuickFixes implements vscode.CodeActionProvider {
   ): vscode.CodeAction[] {
     let quickFixes: vscode.CodeAction[] = [];
     for (let diagnostic of context.diagnostics) {
-      // TODO We can use the diagnostic.code to define different types of fixes
-      // For example: "nothing" => non_existent_row => remove row
-      // For example: missing results => missing_row => add results in a new row
       // TODO We can use the diagnostic.source to search the item in the YAML tree instead of relying on the line number
       // Amount of rows can change, so we can't rely on the line number
       // Also, using the YAML tree we can add new rows precisely where they should be
       const expectedAndGot = diagnosticsUtils.getExpectedGotFromMessage(
         diagnostic.message
       );
-      const got = expectedAndGot[1].toString().trim();
+      const expected = expectedAndGot.expected;
+      const got = expectedAndGot.got;
+
       let codeAction: vscode.CodeAction | undefined;
       // if 'nothing', then we should remove the entire line
       if (got === "nothing") {
@@ -65,7 +68,25 @@ export default class LiquidTestQuickFixes implements vscode.CodeActionProvider {
     const expectedAndGot = diagnosticsUtils.getExpectedGotFromMessage(
       diagnostic.message
     );
-    let got = expectedAndGot[1].toString().trim();
+
+    const resultName = expectedAndGot.name;
+    const originalGot = expectedAndGot.got;
+    const expected = expectedAndGot.expected;
+    const type = expectedAndGot.type;
+    let formattedGot = originalGot;
+
+    // null and arrays are seen as objects and require special formatting
+    if (type === "object") {
+      if (originalGot === "null") {
+        formattedGot = "null";
+      } else {
+        formattedGot = `[${originalGot
+          .split(",")
+          .map((item: any) => `"${item.trim()}"`)
+          .join(", ")}]`;
+      }
+    }
+
     const rowContent = document.lineAt(range.start.line);
     let indexContentStart = rowContent.text.match(/:/)?.index;
     let indexContentEnd =
@@ -76,29 +97,46 @@ export default class LiquidTestQuickFixes implements vscode.CodeActionProvider {
     }
     // +2 to consider ":" and and extra whitespace
     indexContentStart += 2;
-    // Strings should be wrapped in double quotes
-    const numberCheck = Number(got);
-    if (Number.isNaN(numberCheck) && got !== "null") {
-      got = '"' + got + '"';
-    }
+    // Arrays won't have quotes and won't be numbers should be wrapped in square brackets
+    // Booleans will be true or false and not wrapped within quotes
+
     // element is empty after ":" => we need to add one extra space after ":"
     if (indexContentStart === indexContentEnd) {
-      got = " " + got;
+      formattedGot = " " + formattedGot;
     }
-    // Fix to replace content after ":" with the "got" value
-    const fixReplace = new vscode.CodeAction(
-      `Set to ${got}`,
-      vscode.CodeActionKind.QuickFix
-    );
-    fixReplace.edit = new vscode.WorkspaceEdit();
-    fixReplace.edit.replace(
-      document.uri,
-      new vscode.Range(
+
+    let fixProposal: vscode.CodeAction;
+
+    if (expected === "nothing") {
+      const newLine = `\n      ${resultName}: ${formattedGot}`;
+
+      fixProposal = new vscode.CodeAction(
+        `Add line for ${resultName}: ${formattedGot}`,
+        vscode.CodeActionKind.QuickFix
+      );
+      fixProposal.edit = new vscode.WorkspaceEdit();
+      fixProposal.edit.insert(
+        document.uri,
         new vscode.Position(range.start.line, indexContentStart),
-        new vscode.Position(range.start.line, indexContentEnd)
-      ),
-      got
-    );
-    return fixReplace;
+        newLine
+      );
+    } else {
+      // Fix to replace content after ":" with the "got" value
+      fixProposal = new vscode.CodeAction(
+        `Set to ${formattedGot}`,
+        vscode.CodeActionKind.QuickFix
+      );
+      fixProposal.edit = new vscode.WorkspaceEdit();
+      fixProposal.edit.replace(
+        document.uri,
+        new vscode.Range(
+          new vscode.Position(range.start.line, indexContentStart),
+          new vscode.Position(range.start.line, indexContentEnd)
+        ),
+        formattedGot
+      );
+    }
+
+    return fixProposal;
   }
 }

--- a/src/utilities/diagnosticsUtils.ts
+++ b/src/utilities/diagnosticsUtils.ts
@@ -5,21 +5,27 @@
  * @example
  * getExpectedGotFromMessage("Expected: 1 Got: 2") // ["1", "2"]
  */
-export function getExpectedGotFromMessage(message: string): string[] {
-  const output = [];
-  const expectedRegex = /Expected:\s*([^(]+)/g;
+export function getExpectedGotFromMessage(message: string): any {
+  const nameRegex = /^\[(.*?)\]/;
+  const expectedRegex = /Expected:\s*(.*?)\s*\(/;
+  const gotRegex = /Got:\s*(.*?)\s*\(/;
+  const typeRegex = /\)\s*\|\s*Got:.*\((.*?)\)/;
+
+  const nameMatch = message.match(nameRegex);
   const expectedMatch = message.match(expectedRegex);
-  if (expectedMatch) {
-    output.push(expectedMatch[0].replace("Expected: ", ""));
-  } else {
-    output.push("");
-  }
-  const gotRegex = /Got:\s*([^(]+)/g;
   const gotMatch = message.match(gotRegex);
-  if (gotMatch) {
-    output.push(gotMatch[0].replace("Got: ", ""));
-  } else {
-    output.push("");
-  }
-  return output;
+  const typeMatch = message.match(typeRegex);
+
+  const result = {
+    name: nameMatch ? nameMatch[1] : "",
+    expected: expectedMatch
+      ? expectedMatch[1] === "null"
+        ? null
+        : expectedMatch[1]
+      : "",
+    got: gotMatch ? gotMatch[1] : "",
+    type: typeMatch ? typeMatch[1] : ""
+  };
+
+  return result;
 }


### PR DESCRIPTION
## Description

For certain liquid test expectation errors, the proposed quick fix was not adding it correctly. 

Fixes #12 

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- [x] README updated (if needed)
- [x] Version updated (if needed)
- [x] Changelog updated (if needed)
- [x] Documentation updated (if needed)
