### PR TITLE
Show an error message when included part does not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.18.0]
+
+- Check if text parts included in liquid code exists and are properly added to `config.json` of the template.
+- Fix shared part included regular expression. It was not considering optional arguments. Match shared part parts with optional arguments.
+
 ## [1.17.0]
 
 - Add snippets for drops and filters, and expanding existing snippets, alongisde refactoring documentation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import AddClosingTag from "./lib/addClosingTag";
 import DiagnosticCollectionsHandler from "./lib/diagnostics/diagnosticCollectionsHandler";
-import SharedPartsVerifier from "./lib/diagnostics/sharedPartsVerifier";
+import PartsVerifier from "./lib/diagnostics/partsVerifier";
 import ExtensionContext from "./lib/extensionContext";
 import FirmHandler from "./lib/firmHandler";
 import LiquidLinter from "./lib/liquidLinter";
@@ -29,7 +29,7 @@ export async function activate(context: vscode.ExtensionContext) {
   DiagnosticCollectionsHandler.plug();
 
   new LiquidLinter();
-  new SharedPartsVerifier();
+  new PartsVerifier();
   new AddClosingTag();
   new QuickFixesProviders();
   new TemplateCommander();

--- a/src/lib/quickFixes/liquidQuickFixes.ts
+++ b/src/lib/quickFixes/liquidQuickFixes.ts
@@ -1,5 +1,13 @@
 import * as vscode from "vscode";
 
+type MissingSharedPartDetails = {
+  sharedPartName: string;
+  templateHandle: string;
+  templateType: string;
+  firmId: string;
+  missing: boolean;
+};
+
 export default class LiquidQuickFixes implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [
     vscode.CodeActionKind.QuickFix
@@ -13,30 +21,28 @@ export default class LiquidQuickFixes implements vscode.CodeActionProvider {
   ): vscode.CodeAction[] {
     let quickFixes: vscode.CodeAction[] = [];
     for (let diagnostic of context.diagnostics) {
-      let details = this.getDetailsFromMessage(diagnostic.message);
-      if (!details) {
-        continue;
+      // missing shared part?
+      let sharedPartDetails = this.getMissingSharedPartFromMessage(diagnostic.message);
+      if (sharedPartDetails) {
+        let codeAction = this.createMissingSharedPartQuickFix(sharedPartDetails);
+        quickFixes.push(codeAction);
       }
-      let identifier = `addSharedPart.${details.sharedPartName}.${details.templateHandle}.${details.templateType}.${details.firmId}`;
-      let title = `${details.missing ? "Create and add" : "Add"} shared part "${
-        details.sharedPartName
-      }" to template "${details.templateHandle}" in firm "${details.firmId}"`;
-      const codeActionAddSharedPart = new vscode.CodeAction(
-        title,
-        vscode.CodeActionKind.QuickFix
-      );
-      // Command is created when the diagnostic is created
-      // Attach command to quickFix
-      codeActionAddSharedPart.command = {
-        command: identifier,
-        title: title
-      };
-      quickFixes.push(codeActionAddSharedPart);
+      // missing part?
+      let partName = this.getMissingPartFromMessage(diagnostic.message);
+      if (partName) {
+        let codeAction = this.createMissingPartQuickFix(partName);
+        quickFixes.push(codeAction);
+      }
     }
     return quickFixes;
   }
 
-  private getDetailsFromMessage(message: string) {
+  /**
+   * It extracts the missing shared part details from the diagnostic message
+   * @param message - The diagnostic message
+   * @returns - The missing shared part details needed to create the quickFix
+   */
+  private getMissingSharedPartFromMessage(message: string) {
     const sharedPartRegex = /Shared part "([^"]+)"/;
     const templateRegex = /template "([^"]+)"/;
     const firmIdRegex = /firm id "([^"]+)"/;
@@ -55,12 +61,61 @@ export default class LiquidQuickFixes implements vscode.CodeActionProvider {
     if (!sharedPartName || !templateHandle || !templateType || !firmId) {
       return undefined;
     }
+
     return {
       sharedPartName: sharedPartName,
       templateHandle: templateHandle,
       templateType: templateType,
       firmId: firmId,
       missing: missing
+    } as MissingSharedPartDetails;
+  }
+
+  /**
+   * It extracts the missing part name from the diagnostic message
+   * @param message - The diagnostic message
+   * @returns - The missing part name needed to create the quickFix
+  */
+  private getMissingPartFromMessage(message: string) {
+    const partRegex = /Part "([^"]+)"/;
+    const partMatch = message.match(partRegex);
+    const partName = partMatch ? partMatch[1] : undefined;
+    return partName;
+  }
+  
+  private createMissingSharedPartQuickFix(details: MissingSharedPartDetails) {
+    let identifier = `addSharedPart.${details.sharedPartName}.${details.templateHandle}.${details.templateType}.${details.firmId}`;
+    let title = `${details.missing ? "Create and add" : "Add"} shared part "${
+      details.sharedPartName
+    }" to template "${details.templateHandle}" in firm "${details.firmId}"`;
+    const codeActionAddSharedPart = new vscode.CodeAction(
+      title,
+      vscode.CodeActionKind.QuickFix
+    );
+    // Command is created when the diagnostic is created
+    // Attach command to quickFix
+    codeActionAddSharedPart.command = {
+      command: identifier,
+      title: title
     };
+
+    return codeActionAddSharedPart;
+  }
+
+  private createMissingPartQuickFix(partName: string) {
+    let identifier = `addPart.${partName}`;
+    let title = `Create part "${partName}" if it does not exist, and add it to the template's config.json file.`;
+
+    // Create the quickFix
+    const codeActionCreatePart = new vscode.CodeAction(
+      title,
+      vscode.CodeActionKind.QuickFix,
+    );
+    codeActionCreatePart.command = {
+      command: identifier,
+      title: title
+    };
+
+    return codeActionCreatePart;
   }
 }


### PR DESCRIPTION
## Description

Similar to what we currently do with shared parts (show a warning or error message based on if the shared part is added to the firm). Now also check if parts included in liquid are properly listed in the `config.json` file

- Check if part exists and it's included in config.
- If not, show an error message.
- Create a quick fix to create/link the misising part.

![Screenshot from 2024-06-26 12-00-15](https://github.com/silverfin/silverfin-vscode/assets/99397124/3042ebc8-07b5-4af0-8981-bc590b46d308)
![Screenshot from 2024-06-26 11-57-28](https://github.com/silverfin/silverfin-vscode/assets/99397124/cedbc664-5efd-404e-981f-4cf3f91dbc64)
![Screenshot from 2024-06-26 11-57-37](https://github.com/silverfin/silverfin-vscode/assets/99397124/2be823c2-11f0-4ff4-b349-d0de16fbba6f)





## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [x] Changelog updated (if needed)
- [ ] Documentation updated (if needed)
