### PR TITLE
Support Account Templates Liquid Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.21.0]
+
+- Fix issues with liquid testing for reconciliation texts.
+- Support liquid testing for account templates.
+
 ## [1.20.2]
 
 - Revert silverfin-cli version to 1.31.0 (as following versions introduce breaking changes related to liquid testing for account templates currently not supported in the extension)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3477,8 +3477,8 @@
       }
     },
     "node_modules/silverfin-cli": {
-      "version": "1.31.0",
-      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#0432381979d109d18a13c15c73e23fd43d63136b",
+      "version": "1.32.0",
+      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#cf44c4144e923cfbe980fafe05d431134b5ca839",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.20.2",
+      "version": "1.21.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {

--- a/src/lib/liquidTestHandler.ts
+++ b/src/lib/liquidTestHandler.ts
@@ -89,10 +89,12 @@ export default class LiquidTestHandler {
         previewOnly,
         htmlRenderMode
       });
+      const templateType = "reconciliationText"; // TODO: temporal fix until account templates are supported
       // Test Run
       let response: types.ResponseObject =
         await SilverfinToolkit.liquidTestRunner.runTests(
           this.firmId,
+          templateType,
           templateHandle,
           testName,
           false,

--- a/src/lib/sidebar/main.ts
+++ b/src/lib/sidebar/main.ts
@@ -103,7 +103,7 @@ function postMessageSetDefaultFirm() {
 // They should also have an attribute named "data-test-name" to identify the test to run
 // They should also have an attribute named "data-template-type" to identify the template type (reconciliationText or accountTemplate)
 // They should also have an attribute named "data-template-handle" to identify the template handle
-// <vscode-button class="run-test" data-html-type="input" data-test-name="test_name">
+// <vscode-button class="run-test" data-html-type="input" data-test-name="test_name" data-template-handle="handle" data-template-type="reconciliationText">
 function runTestButton() {
   const buttons = document.getElementsByClassName("run-test");
   const buttonsArray = Array.from(buttons);

--- a/src/lib/sidebar/panelTests.ts
+++ b/src/lib/sidebar/panelTests.ts
@@ -276,6 +276,7 @@ export default class TestsViewProvider implements vscode.WebviewViewProvider {
         case "run-test":
           previewOnly = message.htmlType === "none" ? false : true;
           this.liquidTestRunner.runTest(
+            message.templateType,
             message.templateHandle,
             message.testName,
             previewOnly,
@@ -296,8 +297,11 @@ export default class TestsViewProvider implements vscode.WebviewViewProvider {
             (await templateUtils.getTemplateHandle()) || "";
           this.lockedHandle = templateHandle;
           previewOnly = message.htmlType === "none" ? false : true;
+          const templateType =
+            (await templateUtils.getTemplateType()) as types.testableTemplateTypes;
           this.testDetails = {
             templateHandle,
+            templateType,
             testName: message.testName,
             previewOnly: previewOnly,
             htmlType: message.htmlType
@@ -319,6 +323,7 @@ export default class TestsViewProvider implements vscode.WebviewViewProvider {
     this.lockedHandle = "";
     this.testDetails = {
       templateHandle: "",
+      templateType: "" as types.testableTemplateTypes,
       testName: "",
       previewOnly: false,
       htmlType: "none"
@@ -367,6 +372,7 @@ export default class TestsViewProvider implements vscode.WebviewViewProvider {
       switch (this.devModeOption) {
         case "liquid-tests":
           this.liquidTestRunner.runTest(
+            this.testDetails.templateType,
             this.testDetails.templateHandle,
             this.testDetails.testName,
             this.testDetails.previewOnly,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -109,6 +109,7 @@ export type htmlOpenModes = "input" | "preview";
 
 export type TestRunDetails = {
   templateHandle: string;
+  templateType: testableTemplateTypes;
   testName: string;
   previewOnly: boolean;
   htmlType: htmlRenderModes;
@@ -119,6 +120,8 @@ export type templateTypes =
   | "exportFile"
   | "accountTemplate"
   | "sharedPart";
+
+export type testableTemplateTypes = "reconciliationText" | "accountTemplate";
 
 export type sharedPartUsedIn = {
   id: { [key: string]: Number };


### PR DESCRIPTION
## Description

- Upgrade silverfin-cli to latest version and solve breaking changes that broke reconciliation text testing in the extension
- support liquid testing for account templates in the extension

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [X] Changelog updated (if needed)
- [ ] Documentation updated (if needed)
