### PR TITLE
Allow subfolders in liquid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "silverfin-development-toolkit" extension will be documented in this file.
 
+## [1.24.0]
+
+- Allow subfolders in template directories
+- Bump silverfin CLI version (1.56.0)
+
 ## [1.23.0]
 
 - Make extension compatible with the latest CLI version (1.55.2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "silverfin-development-toolkit",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-development-toolkit",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.33",
         "@vscode/webview-ui-toolkit": "^1.2.2",
         "axios": "^1.17.0",
-        "silverfin-cli": "github:silverfin/silverfin-cli#428bccee8f83b19accf571f781f905f9e00bb36c",
+        "silverfin-cli": "github:silverfin/silverfin-cli#a66cebf325f5050d8028d897d84cd1cde0f0f6ed",
         "yaml": "^2.2.2"
       },
       "devDependencies": {
@@ -3478,9 +3478,9 @@
       }
     },
     "node_modules/silverfin-cli": {
-      "version": "1.55.2",
-      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#428bccee8f83b19accf571f781f905f9e00bb36c",
-      "integrity": "sha512-YQQOJ2a8W5XHWYUSpkcxQhwqz3LhZdlItUYiusHhbXNUesFMfk1RHxi35s5NrY2qfl6P8P4QQnHjT4/aKz+D0A==",
+      "version": "1.56.0",
+      "resolved": "git+ssh://git@github.com/silverfin/silverfin-cli.git#a66cebf325f5050d8028d897d84cd1cde0f0f6ed",
+      "integrity": "sha512-6yCb5PCJpPtLepQZex/ycnEqEJhOa+R7yfkZ4UEG1NxhF0EynLFbZRRTVaR8/E1J+R1DH8eSnnfUwTt9DJQp0g==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverfin-development-toolkit",
   "displayName": "Silverfin Development Toolkit",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "publisher": "Silverfin",
   "icon": "resources/sf-icon.png",
   "engines": {
@@ -28,7 +28,7 @@
     "@vscode/codicons": "^0.0.33",
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "axios": "^1.17.0",
-    "silverfin-cli": "github:silverfin/silverfin-cli#428bccee8f83b19accf571f781f905f9e00bb36c",
+    "silverfin-cli": "github:silverfin/silverfin-cli#a66cebf325f5050d8028d897d84cd1cde0f0f6ed",
     "yaml": "^2.2.2"
   },
   "contributes": {

--- a/src/lib/diagnostics/partsVerifier.ts
+++ b/src/lib/diagnostics/partsVerifier.ts
@@ -75,13 +75,14 @@ export default class PartsVerifier {
       return;
     }
 
+    // Part names from config are a flat list of identifiers (keys in text_parts), matching include paths
     const existingParts = (await templateUtils.getTemplateParts()) || [];
 
     // Compare the two arrays and find the differences (parts used but not existing)
     const missingParts = partsUsed.filter(
       (part) =>
         !existingParts.some(
-          (existing) => existing === part || part.endsWith(`/${existing}`)
+          (existing) => existing === part || existing.endsWith(`/${part}`)
         )
     );
     if (missingParts.length === 0) {
@@ -123,7 +124,9 @@ export default class PartsVerifier {
   }
 
   /**
-   * Inspect the liquid code of the file and search for the use of parts or shared parts
+   * Inspect the liquid code of the file and search for the use of parts or shared parts.
+   * Include tags always use a flat path (e.g. "parts/foo" or "parts/subfolder/bar");
+   * this works on a flat structure even when the template config has multiple subfolders.
    * @param type string 'sharedPart' | 'part'
    * @returns string[] | undefined
    * @example

--- a/src/lib/diagnostics/partsVerifier.ts
+++ b/src/lib/diagnostics/partsVerifier.ts
@@ -79,7 +79,10 @@ export default class PartsVerifier {
 
     // Compare the two arrays and find the differences (parts used but not existing)
     const missingParts = partsUsed.filter(
-      (part) => !existingParts.includes(part)
+      (part) =>
+        !existingParts.some(
+          (existing) => existing === part || part.endsWith(`/${existing}`)
+        )
     );
     if (missingParts.length === 0) {
       this.extensionLogger.log("All parts already exist.");

--- a/src/lib/sidebar/panelTemplateParts.ts
+++ b/src/lib/sidebar/panelTemplateParts.ts
@@ -138,16 +138,19 @@ export default class TemplatePartsViewProvider
     partNames = Object.keys(configData.text_parts) || [];
     const partsRows = partNames
       .map(
-        (partName: string, index: number) => /*html*/ `<vscode-data-grid-row>
+        (partName: string, index: number) => {
+          const partPath = configData.text_parts[partName];
+          return /*html*/ `<vscode-data-grid-row>
                         <vscode-data-grid-cell grid-column="1">
                         ${index + 1}. ${partName}
                         </vscode-data-grid-cell>
                         <vscode-data-grid-cell grid-column="2" class="vs-actions">
-                          <vscode-button appearance="icon" aria-label="Open-file" class="open-file" data-value="/${templateFolder}/${handle}/text_parts/${partName}.liquid" title="Open file in a new tab">
+                          <vscode-button appearance="icon" aria-label="Open-file" class="open-file" data-value="/${templateFolder}/${handle}/${partPath}" title="Open file in a new tab">
                             <i class="codicon codicon-go-to-file"></i>
                           </vscode-button>
                         </vscode-data-grid-cell>
-                      </vscode-data-grid-row>`
+                      </vscode-data-grid-row>`;
+        }
       )
       .join("");
 

--- a/src/utilities/templateUtils.ts
+++ b/src/utilities/templateUtils.ts
@@ -1,4 +1,5 @@
 import { posix } from "path";
+import * as fs from "fs";
 import * as vscode from "vscode";
 import * as utils from "./utils";
 
@@ -219,20 +220,41 @@ export async function getTemplateParts() {
   return Object.keys(templateConfigData.text_parts);
 }
 
+/**
+ * Recursively get all part names (relative paths without .liquid) under text_parts.
+ * Supports flat (part_name) and nested (subfolder/part_name, subfolder1/subfolder2/part_name) paths.
+ */
+async function getPartNamesFromDirectory(partsPath: string): Promise<string[]> {
+  const partNames: string[] = [];
+  const entries = await vscode.workspace.fs.readDirectory(
+    vscode.Uri.file(partsPath)
+  );
+  for (const [name, fileType] of entries) {
+    if (fileType === vscode.FileType.File && name.endsWith(".liquid")) {
+      partNames.push(name.replace(".liquid", ""));
+    } else if (fileType === vscode.FileType.Directory) {
+      const subPath = posix.join(partsPath, name);
+      const subNames = await getPartNamesFromDirectory(subPath);
+      partNames.push(...subNames.map((sub) => `${name}/${sub}`));
+    }
+  }
+  return partNames;
+}
+
 export async function removeDeletedParts() {
   const templateBasePath = await getTemplateBasePath();
   if (!templateBasePath) {
     return false;
   }
   const partsPath = posix.join(templateBasePath, "text_parts");
-  const parts = await vscode.workspace.fs.readDirectory(
-    vscode.Uri.file(partsPath)
-  );
-  const partsInDirectory = parts.map((part) => part[0].replace(".liquid", ""));
+  const partsInDirectory = await getPartNamesFromDirectory(partsPath);
   const partsInConfig = await getTemplateParts();
 
   const partsToDelete = partsInConfig.filter(
-    (part) => !partsInDirectory.includes(part)
+    (part) =>
+      !partsInDirectory.some(
+        (dirPart) => dirPart === part || dirPart.endsWith(`/${part}`)
+      )
   );
 
   if (partsToDelete.length === 0) {
@@ -272,7 +294,7 @@ async function createTemplatePart(partName: string) {
   }
   const newPartPath = posix.join(
     templateBasePath,
-    `text_parts`,
+    "text_parts",
     `${partName}.liquid`
   );
   const newPartContent = Uint8Array.from(

--- a/src/utilities/templateUtils.ts
+++ b/src/utilities/templateUtils.ts
@@ -1,5 +1,4 @@
 import { posix } from "path";
-import * as fs from "fs";
 import * as vscode from "vscode";
 import * as utils from "./utils";
 
@@ -215,6 +214,10 @@ export async function getTemplateLiquidTestsPath() {
   }
 }
 
+/**
+ * Returns the list of part names (flat identifiers) from the template config.
+ * Include tags in liquid use this same flat structure regardless of subfolders in config.
+ */
 export async function getTemplateParts() {
   const templateConfigData = await getTemplateConfigData();
   return Object.keys(templateConfigData.text_parts);
@@ -226,9 +229,12 @@ export async function getTemplateParts() {
  */
 async function getPartNamesFromDirectory(partsPath: string): Promise<string[]> {
   const partNames: string[] = [];
-  const entries = await vscode.workspace.fs.readDirectory(
-    vscode.Uri.file(partsPath)
-  );
+  let entries: [string, vscode.FileType][];  
+    try {  
+      entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(partsPath));  
+    } catch {  
+      return partNames; // Missing/inaccessible directory  
+    } 
   for (const [name, fileType] of entries) {
     if (fileType === vscode.FileType.File && name.endsWith(".liquid")) {
       partNames.push(name.replace(".liquid", ""));


### PR DESCRIPTION
## Description

Changes in parallel with the [CLI change](https://github.com/silverfin/silverfin-cli/pull/248) to allow subfolders in templates.

- Opening a part will now also open the part if it is in a subfolder
- Make sure that parts from a subfolder are not deleted whenever the sidebar is opened

Can be tested via the VScode debug panel.

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [ ] Version updated (if needed)
- [ ] Changelog updated (if needed)
- [ ] Documentation updated (if needed)
